### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This provides very simple way of provisioning redis instances.
 
 All dbs are stored in the `db/` subdirectory together with .sock files
 
-##Master / Slave mode
+## Master / Slave mode
 
 Redismux can automatically configure master slave replication. 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
